### PR TITLE
feat: Add prettier and eslint mirror repos to precommit config yaml file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,11 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 21.4b2
+    rev: 22.1.0
     hooks:
     -   id: black
         args: ['--skip-string-normalization','--line-length','100']
         exclude: ^.*\b(migrations)\b.*$
+        additional_dependencies: ['click==8.0.4']
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,9 +40,3 @@ repos:
     hooks:
     -   id: bandit
         args: ['-iii', '-ll','--skip','B301']
--   repo: https://github.com/pre-commit/mirrors-eslint
-    rev: 'v8.2.0'
-    hooks:
-      - id: eslint
-        files: \.[jt]sx?$|\.vue?$
-        types: [file]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.10.1
     hooks:
     -   id: black
         args: ['--skip-string-normalization','--line-length','100']
         exclude: ^.*\b(migrations)\b.*$
         additional_dependencies: ['click==8.0.4']
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.5.0
     hooks:
     -   id: check-added-large-files
         args: ['--maxkb=10000']
@@ -28,20 +28,20 @@ repos:
         exclude: ((^.*\b(factories)\b.*$)|(^.*\b(fixtures)\b.*$)|(^.*\b(mixins)\b.*$)|(^.*\b(test_app)\b.*$))
     -   id: trailing-whitespace
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.8.2
+    rev: v3.12.0
     hooks:
     -   id: reorder-python-imports
 -   repo: https://github.com/pycqa/pylint
-    rev: v2.14.5
+    rev: v3.0.2
     hooks:
     -   id: pylint
         exclude: ^.*\b(migrations)\b.*$
 -   repo: https://github.com/pycqa/bandit
-    rev: 1.7.4
+    rev: v1.7.5
     hooks:
     -   id: bandit
         args: ['-iii', '-ll','--skip','B301']
 -   repo: https://github.com/avilaton/add-msg-issue-prefix-hook
-    rev: v0.0.5  # Use the ref you want to point at
+    rev: v0.0.9  # Use the ref you want to point at
     hooks:
     -   id: add-msg-issue-prefix

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     hooks:
     -   id: reorder-python-imports
 -   repo: https://github.com/pycqa/pylint
-    rev: v2.8.2
+    rev: v2.13.7
     hooks:
     -   id: pylint
         exclude: ^.*\b(migrations)\b.*$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.6.0
     hooks:
     -   id: black
         args: ['--skip-string-normalization','--line-length','100']
         exclude: ^.*\b(migrations)\b.*$
         additional_dependencies: ['click==8.0.4']
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.3.0
     hooks:
     -   id: check-added-large-files
         args: ['--maxkb=10000']
@@ -28,16 +28,16 @@ repos:
         exclude: ((^.*\b(factories)\b.*$)|(^.*\b(fixtures)\b.*$))
     -   id: trailing-whitespace
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.5.0
+    rev: v3.8.2
     hooks:
     -   id: reorder-python-imports
 -   repo: https://github.com/pycqa/pylint
-    rev: v2.13.7
+    rev: v2.14.5
     hooks:
     -   id: pylint
         exclude: ^.*\b(migrations)\b.*$
 -   repo: https://github.com/pycqa/bandit
-    rev: 1.7.0
+    rev: 1.7.4
     hooks:
     -   id: bandit
         args: ['-iii', '-ll','--skip','B301']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     -   id: pylint
         exclude: ^.*\b(migrations)\b.*$
 -   repo: https://github.com/pycqa/bandit
-    rev: v1.7.5
+    rev: 1.7.5
     hooks:
     -   id: bandit
         args: ['-iii', '-ll','--skip','B301']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,15 @@ repos:
     rev: v0.0.9  # Use the ref you want to point at
     hooks:
     -   id: add-msg-issue-prefix
+-  repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+    -  id: prettier
+       files: \.(js|css|html|vue)$
+       types: [file]
+-  repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v8.56.0
+    hooks:
+      - id: eslint
+        files: \.(js|css|html|vue)$
+        types: [file]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,7 @@ repos:
     hooks:
     -   id: bandit
         args: ['-iii', '-ll','--skip','B301']
+-   repo: https://github.com/avilaton/add-msg-issue-prefix-hook
+    rev: v0.0.5  # Use the ref you want to point at
+    hooks:
+    -   id: add-msg-issue-prefix

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     -   id: requirements-txt-fixer
     -   id: name-tests-test
         args: ['--django']
-        exclude: ((^.*\b(factories)\b.*$)|(^.*\b(fixtures)\b.*$))
+        exclude: ((^.*\b(factories)\b.*$)|(^.*\b(fixtures)\b.*$)|(^.*\b(mixins)\b.*$)|(^.*\b(test_app)\b.*$))
     -   id: trailing-whitespace
 -   repo: https://github.com/asottile/reorder_python_imports
     rev: v3.8.2

--- a/.pylintrc
+++ b/.pylintrc
@@ -156,12 +156,6 @@ disable=abstract-method,
 # mypackage.mymodule.MyReporterClass.
 output-format=text
 
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]". This option is deprecated
-# and it will be removed in Pylint 2.0.
-files-output=no
-
 # Tells whether to display a full report or only the messages
 reports=no
 
@@ -279,12 +273,6 @@ ignore-long-lines=(?x)(
 # Allow the body of an if to be on the same line as the test if there is no
 # else.
 single-line-if-stmt=yes
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=
 
 # Maximum number of lines in a module
 max-module-lines=99999

--- a/.pylintrc
+++ b/.pylintrc
@@ -145,7 +145,8 @@ disable=abstract-method,
         C0301,
         C0330,
         C0326,
-        W1405
+        W1405,
+        C0209
 
 
 [REPORTS]


### PR DESCRIPTION
Added mirror repos to be used as pre-commit hooks for frontend applications. These hooks will only be executed for html/css/js/vue files.